### PR TITLE
Allowing additional parameters for json call parse

### DIFF
--- a/lib/rcall.js
+++ b/lib/rcall.js
@@ -21,7 +21,7 @@ function rCall(command, args, callback, {
         let myData = data;
 
         if (!myErr) {
-            if (/json$/.test(url)) {
+            if (/json$/.test(url)||/json\?/.test(url)) {
                 myData = JSON.parse(data);
             }
             if (/\/ocpu\/tmp/.test(data)) {


### PR DESCRIPTION
Parse json even when ocpu.rCall has additional parameters after json. Currently, when adding parameters it returns strings instead JSON.
For example:
/R/.val/json?digits=2&use_signif=true

Allowing for parsing json even if there are some extra parameters to format the json output. Based on that issue, and @jeroen response:
https://github.com/jeroen/jsonlite/issues/166#issuecomment-449059698

Example:
https://cloud.opencpu.org/ocpu/tmp/x0ef3399162d21a/R/.val/json?digits=2&use_signif=true


